### PR TITLE
fix error: variable 'local_index' set but not used

### DIFF
--- a/drivers/misc/mediatek/typec/tcpc/pd_dpm_alt_mode_dp.c
+++ b/drivers/misc/mediatek/typec/tcpc/pd_dpm_alt_mode_dp.c
@@ -349,7 +349,7 @@ static inline uint8_t dp_dfp_u_select_mode(struct pd_port *pd_port,
 	struct svdm_mode *remote, *local;
 	int i, j;
 	int match_score, best_match_score = 0;
-	int local_index = -1, remote_index = -1;
+	int remote_index = -1;
 	struct tcpc_device __maybe_unused *tcpc = pd_port->tcpc;
 
 	local = &svid_data->local_mode;
@@ -368,7 +368,6 @@ static inline uint8_t dp_dfp_u_select_mode(struct pd_port *pd_port,
 				dp_remote_mode, &local_dp_config,
 				&remote_dp_config);
 			if (match_score >  best_match_score) {
-				local_index = j;
 				remote_index = i;
 				dp_data->local_config = local_dp_config;
 				dp_data->remote_config = remote_dp_config;


### PR DESCRIPTION
../../../../../../kernel/xiaomi/cannon/drivers/misc/mediatek/typec/tcpc/pd_dpm_alt_mode_dp.c:352:6: error: variable 'local_index' set but not used [-Werror,-Wunused-but-set- variable]
        int local_index = -1, remote_index = -1;
            ^
1 error generated.